### PR TITLE
Copies all the elements of existing dataset to new harvested dataset

### DIFF
--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -229,10 +229,13 @@ class DCATJSONHarvester(DCATHarvester):
         if status == 'change':
             existing_dataset = self._get_existing_dataset(harvest_object.guid)
             if existing_dataset:
-                copy_across_resource_ids(existing_dataset, package_dict)
-                copy_across_dataset_groups(existing_dataset, package_dict)
-                copy_across_dataset_tayside_elements(existing_dataset, package_dict)
-
+                # Instead of copying only resource_id and groups from existing
+                # dataset to package_dict. Update existing dataset with the 
+                # contents of package_dict and use that as package_dict. This
+                # will copy everything to the new package_dict.
+                existing_dataset.update(package_dict)
+                package_dict = existing_dataset
+                
         # Allow custom harvesters to modify the package dict before creating
         # or updating the package
         package_dict = self.modify_package_dict(package_dict,
@@ -296,69 +299,3 @@ class DCATJSONHarvester(DCATHarvester):
             model.Session.commit()
 
         return True
-
-def copy_across_resource_ids(existing_dataset, harvested_dataset):
-    '''Compare the resources in a dataset existing in the CKAN database with
-    the resources in a freshly harvested copy, and for any resources that are
-    the same, copy the resource ID into the harvested_dataset dict.
-    '''
-    # take a copy of the existing_resources so we can remove them when they are
-    # matched - we don't want to match them more than once.
-    existing_resources_still_to_match = \
-        [r for r in existing_dataset.get('resources')]
-
-    # we match resources a number of ways. we'll compute an 'identity' of a
-    # resource in both datasets and see if they match.
-    # start with the surest way of identifying a resource, before reverting
-    # to closest matches.
-    resource_identity_functions = [
-        lambda r: r['uri'],  # URI is best
-        lambda r: (r['url'], r['title'], r['format']),
-        lambda r: (r['url'], r['title']),
-        lambda r: r['url'],  # same URL is fine if nothing else matches
-    ]
-
-    for resource_identity_function in resource_identity_functions:
-        # calculate the identities of the existing_resources
-        existing_resource_identities = {}
-        for r in existing_resources_still_to_match:
-            try:
-                identity = resource_identity_function(r)
-                existing_resource_identities[identity] = r
-            except KeyError:
-                pass
-
-        # calculate the identities of the harvested_resources
-        for resource in harvested_dataset.get('resources'):
-            try:
-                identity = resource_identity_function(resource)
-            except KeyError:
-                identity = None
-            if identity and identity in existing_resource_identities:
-                # we got a match with the existing_resources - copy the id
-                matching_existing_resource = \
-                    existing_resource_identities[identity]
-                resource['id'] = matching_existing_resource['id']
-                # make sure we don't match this existing_resource again
-                del existing_resource_identities[identity]
-                existing_resources_still_to_match.remove(
-                    matching_existing_resource)
-        if not existing_resources_still_to_match:
-            break
-
-
-def copy_across_dataset_groups(existing_dataset, harvested_dataset):
-    '''Copies the groups any existing datasets
-    are in to the newly harvested datasets'''
-    existing_groups = existing_dataset.get('groups')
-
-    if existing_groups:
-        harvested_dataset['groups'] = existing_groups
-
-def copy_across_dataset_tayside_elements(existing_dataset, harvested_dataset):
-    '''Copies the tayside elements any existing datasets
-    have to the newly harvested datasets'''
-    existing_frequency = existing_dataset.get('frequency')
-
-    if existing_frequency:
-        harvested_dataset.update({'frequency':existing_frequency})

--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -231,6 +231,7 @@ class DCATJSONHarvester(DCATHarvester):
             if existing_dataset:
                 copy_across_resource_ids(existing_dataset, package_dict)
                 copy_across_dataset_groups(existing_dataset, package_dict)
+                copy_across_dataset_tayside_elements(existing_dataset, package_dict)
 
         # Allow custom harvesters to modify the package dict before creating
         # or updating the package
@@ -353,3 +354,11 @@ def copy_across_dataset_groups(existing_dataset, harvested_dataset):
 
     if existing_groups:
         harvested_dataset['groups'] = existing_groups
+
+def copy_across_dataset_tayside_elements(existing_dataset, harvested_dataset):
+    '''Copies the tayside elements any existing datasets
+    have to the newly harvested datasets'''
+    existing_frequency = existing_dataset.get('frequency')
+
+    if existing_frequency:
+        harvested_dataset.update({'frequency':existing_frequency})


### PR DESCRIPTION
Fixes https://gitlab.com/datopian/core/support/-/issues/232

Tayside extension adds an `Update frequency` option to be set while editing a dataset, which is reset every time a dataset is reharvested.
![Screenshot from 2020-07-10 02-30-11](https://user-images.githubusercontent.com/57398621/87092711-5c040f00-c255-11ea-87b8-9aaf4e1a5080.png)

This PR removes functions to add `resource_id` and `group_id` from existing dataset to new harvested dataset and instead merges the contents of package_dict(new dataset) into existing dataset and uses that as package_dict. 

Thus updating existing dataset with the contents of package_dict(new dataset) and using that as `package_dict` will contain all the contents of existing dataset and contents fetched from harvest source will overwrite them.
