### PR TITLE
Fixes  'cannot concatenate ‘str’ and ‘NoneType’ objects' error on deleting dataset from a JSON source

### DIFF
--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -193,9 +193,10 @@ class DCATJSONHarvester(DCATHarvester):
                 context, {'id': harvest_object.package_id})
             log.info('Deleted package {0} with guid {1}'
                      .format(harvest_object.package_id, harvest_object.guid))
-            
+
             model.Session.query(HarvestObject).\
-                filter_by(guid=guid).\
+                filter_by(guid=harvest_object.guid).\
+                filter_by(current=True).\
                 update({'current': False}, False)
 
             return True

--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -165,11 +165,8 @@ class DCATJSONHarvester(DCATHarvester):
                 guid=guid, job=harvest_job,
                 package_id=guid_to_package_id[guid],
                 extras=[HarvestObjectExtra(key='status', value='delete')])
-            ids.append(obj.id)
-            model.Session.query(HarvestObject).\
-                filter_by(guid=guid).\
-                update({'current': False}, False)
             obj.save()
+            ids.append(obj.id)
 
         return ids
 
@@ -196,6 +193,10 @@ class DCATJSONHarvester(DCATHarvester):
                 context, {'id': harvest_object.package_id})
             log.info('Deleted package {0} with guid {1}'
                      .format(harvest_object.package_id, harvest_object.guid))
+            
+            model.Session.query(HarvestObject).\
+                filter_by(guid=guid).\
+                update({'current': False}, False)
 
             return True
 


### PR DESCRIPTION
This PR fixes the error of  `TypeError: cannot concatenate ‘str’ and ‘NoneType’ objects` which occurs when a dataset is removed from the source of harvest and causes the harvest job to stuck in an infinite loop. The status never changes from `ongoing` to `finished`.
This also deletes the dataset which has been removed from the source (Applicable for datasets only after this change is in effect. The datasets which were removed before this change wont be removed from ckan. They would have to be deleted manually). 
Fixes: https://gitlab.com/datopian/core/support/-/issues/252